### PR TITLE
Set item label

### DIFF
--- a/iris/src/main/webapp/Scripts/iris.js
+++ b/iris/src/main/webapp/Scripts/iris.js
@@ -330,7 +330,7 @@ This code implements the XDM API for use within item preview app.
                 TDS.Dialog.showProgress();
                 setAccommodations(token);
                 var url = irisUrl + '/Pages/API/content/load?id=' + vendorId;
-                return $.post(url, token, null, 'text').then(function (data) {
+                return $.post(url, token, null, 'json').then(function (data) {
                     resolve(loadContent(data));
                 });
             }
@@ -354,7 +354,7 @@ This code implements the XDM API for use within item preview app.
         TDS.Dialog.showProgress();
         var url = location.href + '/Pages/API/content/loadContent?id=' + vendorId;
         setAccommodations(token);
-        return $.post(url, token, null, 'text').then(function (data) {
+        return $.post(url, token, null, 'json').then(function (data) {
             return loadGroupedContent(data);
         });
     }
@@ -408,7 +408,9 @@ This code implements the XDM API for use within item preview app.
                 throw new Error('item position and id do not match');
             }
 
-            setItemResponse(itemFromPosition || itemFromId, itemResponse.response);
+            if (typeof itemResponse.response !== "undefined") {
+                setItemResponse( itemFromPosition || itemFromId, itemResponse.response );
+            }
 
             if (itemResponse.label) {
                 setItemLabel(itemFromPosition || itemFromId, itemResponse.label);


### PR DESCRIPTION
I'm shooting for a super-minimal change here that fixes two issues we've encountered working with Iris:
1. The Content-Type of the token post was incorrectly advertised as "application/x-www-form-urlencoded" rather than "application/json"
2. Sometimes a student doesn't answer a question, so we have no viable response but would still like to set the item display label.